### PR TITLE
Line 52: PHPDoc tag @param for parameter $request with type mixed is …

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -46,7 +46,7 @@ class ProductController extends Controller
     /**
      * store
      *
-     * @param  mixed $request
+     * @param  Illuminate\Http\Request $request
      * @return RedirectResponse
      */
     public function store(Request $request): RedirectResponse
@@ -110,7 +110,7 @@ class ProductController extends Controller
     /**
      * update
      *
-     * @param  mixed $request
+     * @param  Illuminate\Http\Request $request
      * @param  mixed $id
      * @return RedirectResponse
      */


### PR DESCRIPTION
…not subtype of native type Illuminate\Http\Request.